### PR TITLE
Adds option to render with default value

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ interface TyperProps {
   pauseTime?: number;
   loop?: boolean;
   style?: React.CSSProperties;
+  defaultText?: string;
 }
 
 const Typer: React.FC<TyperProps> = ({
@@ -37,8 +38,9 @@ const Typer: React.FC<TyperProps> = ({
   pauseTime = 1000,
   loop = true,
   style = {},
+  defaultText = '',
 }: TyperProps) => {
-  const [text, setText] = useState('');
+  const [text, setText] = useState(defaultText);
   const [isDeleting, setIsDeleting] = useState(false);
   const [loopNum, setLoopNum] = useState(0);
   const [writingSpeed, setWritingSpeed] = useState(typingSpeed);


### PR DESCRIPTION
This PR adds an option to be able to initiate the component with a default value which might be helpful for Next.js users.

Because the component initially renders with an empty string, crawlers won't correctly index the string when the component is serverside rendered.

When the default value is set to an empty string this is static result from Next.js:

```jsx
<span>
    <span></span>
    <span
         class="typist-cursor"
          style="opacity:0;visibility:visible;color:;animation:blink 1000ms steps(1) infinite;animation-delay:0ms"
    >
      |
    </span>
</span>
```

And, with a default value set the first sentence:

```jsx
<span>
    <span>I got rendered correctly</span>
    <span
         class="typist-cursor"
          style="opacity:0;visibility:visible;color:;animation:blink 1000ms steps(1) infinite;animation-delay:0ms"
    >
      |
    </span>
</span>
```